### PR TITLE
Backport the JSON CEE patch from GStreamer upstream project

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-gstreamer1.5 (1.8.1-1kurento1) UNRELEASED; urgency=medium
+gstreamer1.5 (1.8.1-1kurento2) testing; urgency=medium
 
   [ Jose Antonio Santos Cadenas ]
   * Change debian format
@@ -20,8 +20,9 @@ gstreamer1.5 (1.8.1-1kurento1) UNRELEASED; urgency=medium
   [ Juan Navarro ]
   * Ubuntu 18.04: Fix dependency & disable docs
   * debian/control: Disable docs for Bionic build
+  * debian/rules: Run pre-build command with dh-autoreconf
 
- -- Juan Navarro <juan.navarro@gmx.es>  Wed, 06 Feb 2019 13:12:53 +0100
+ -- Juan Navarro <juan.navarro@gmx.es>  Mon, 14 Oct 2019 17:20:56 +0200
 
 gstreamer1.5 (1.5.0.1) experimental; urgency=medium
 

--- a/gst/gstinfo.c
+++ b/gst/gstinfo.c
@@ -1127,10 +1127,11 @@ gst_debug_log_default (GstDebugCategory * category, GstDebugLevel level,
     strftime (iso8601buf, ISO8601_BUF_SIZE, "%FT%T", &_tm);
     gst_debug_escape_json (gst_debug_message_get (message), message_encoded,
         MAX_JSON_MSG_LEN);
-#define PRINT_FMT "\"proc!id\":\"%d\",\"proc!tid\":%ju,\"pri\":\"%s\",\"subsys\":\"%s\",\"file!name\":\"%s\",\"file!line\":%d,\"native!function\":\"%s\",\"native!object\":\"%s\",\"msg\":\"%s\",\"pname\":\"%s\",\"appname\":\"%s\",\"hostname\":\"%s\",\"gstreamer!level\":%d,\"syslog!level\":%d}\n"
+#define PRINT_FMT "\"proc\":{\"id\":\"%d\",\"tid\":%ju},\"pri\":\"%s\",\"subsys\":\"%s\",\"file\":{\"name\":\"%s\",\"line\":%d},\"native\":{\"function\":\"%s\",\"object\":\"%s\"},\"msg\":\"%s\",\"pname\":\"%s\",\"appname\":\"%s\",\"hostname\":\"%s\",\"gstreamer\":{\"level\":%d},\"syslog\":{\"level\":%d}}\n"
     fprintf (log_file,
-        "{\"time\":\"%s.%09luZ\",\"native!time!elapsed\":%lu," PRINT_FMT,
-        iso8601buf, tv_ns, elapsed, pid, (uintptr_t) g_thread_self (),
+        "{\"time\":\"%s.%09luZ\",\"native\":{\"time\":{\"elapsed\":%lu}},"
+        PRINT_FMT, iso8601buf, tv_ns, elapsed, pid,
+        (uintptr_t) g_thread_self (),
         gst_debug_level_get_name_cee (level),
         gst_debug_category_get_name (category), file, line, function, obj,
         message_encoded, log_pname, log_appname, log_hostname,

--- a/gst/gstinfo.c
+++ b/gst/gstinfo.c
@@ -95,6 +95,7 @@
 #  include <dlfcn.h>
 #endif
 #include <stdio.h>              /* fprintf */
+#include <stdint.h>             /* uintptr_t */
 #include <glib/gstdio.h>
 #include <errno.h>
 #ifdef HAVE_UNISTD_H
@@ -107,6 +108,18 @@
 #ifdef G_OS_WIN32
 #  define WIN32_LEAN_AND_MEAN   /* prevents from including too many things */
 #  include <windows.h>          /* GetStdHandle, windows console */
+#endif
+
+/* for getaddrinfo */
+#ifdef G_OS_WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdio.h>
+#else
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
 #endif
 
 #include "gst_private.h"
@@ -255,6 +268,13 @@ static GSList *__log_functions = NULL;
 
 #define PRETTY_TAGS_DEFAULT  TRUE
 static gboolean pretty_tags = PRETTY_TAGS_DEFAULT;
+
+#define STRUCTURED_JSON_CEE_DEFAULT  FALSE
+static gboolean structured_json_cee = STRUCTURED_JSON_CEE_DEFAULT;
+
+static const gchar *log_pname = 0;
+static const gchar *log_appname = 0;
+static const gchar *log_hostname = 0;
 
 static volatile gint G_GNUC_MAY_ALIAS __default_level = GST_LEVEL_DEFAULT;
 static volatile gint G_GNUC_MAY_ALIAS __use_color = GST_DEBUG_COLOR_MODE_ON;
@@ -405,6 +425,50 @@ _priv_gst_debug_init (void)
   env = g_getenv ("GST_DEBUG");
   if (env) {
     gst_debug_set_threshold_from_string (env, FALSE);
+  }
+
+  env = g_getenv ("GST_DEBUG_STRUCTURED");
+  if (env != NULL) {
+    if (strstr (env, "JSON_CEE")) {
+      structured_json_cee = TRUE;
+      /* pname, hostname and time are mandatory for CEE */
+#if defined(__APPLE__) || defined(__FreeBSD__)
+      log_pname = getprogname ();
+#elif defined(_GNU_SOURCE)
+      log_pname = program_invocation_name;
+#else
+      log_pname = "?";
+#endif
+      /* if running multiple instances of the same pname, user
+         can set a different appname for each instance */
+      log_appname = g_getenv ("GST_DEBUG_APPNAME");
+      if (log_appname == NULL) {
+        log_appname = log_pname;
+      }
+      {
+        struct addrinfo hints, *info;
+        int gai_result;
+
+        char hostname[1024];
+        hostname[1023] = '\0';
+        gethostname (hostname, 1023);
+
+        memset (&hints, 0, sizeof (hints));
+        hints.ai_family = AF_UNSPEC;    /*either IPV4 or IPV6 */
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = AI_CANONNAME;
+
+        if ((gai_result = getaddrinfo (hostname, 0, &hints, &info)) != 0) {
+          log_hostname = "?";
+        } else if (info == NULL) {
+          log_hostname = "?";
+        } else {
+          log_hostname = g_strdup (info->ai_canonname);
+        }
+
+        freeaddrinfo (info);
+      }
+    }
   }
 }
 
@@ -1011,7 +1075,7 @@ gst_debug_log_default (GstDebugCategory * category, GstDebugLevel level,
     GObject * object, GstDebugMessage * message, gpointer user_data)
 {
   gint pid;
-  GstClockTime elapsed;
+  GstClockTime elapsed, now;
   gchar *obj = NULL;
   GstDebugColorMode color_mode;
   FILE *log_file = user_data ? user_data : stderr;
@@ -1036,8 +1100,31 @@ gst_debug_log_default (GstDebugCategory * category, GstDebugLevel level,
   }
 
   elapsed = GST_CLOCK_DIFF (_priv_gst_start_time, gst_util_get_timestamp ());
+  now = g_get_real_time () * 1000;
 
-  if (color_mode != GST_DEBUG_COLOR_MODE_OFF) {
+  if (structured_json_cee == TRUE) {
+    GTimeVal tv;
+    uint64_t tv_ns = GST_TIME_AS_NSECONDS (now) % GST_SECOND;
+    struct tm _tm;
+#define ISO8601_BUF_SIZE 32
+    char iso8601buf[ISO8601_BUF_SIZE + 1];
+#define MAX_JSON_MSG_LEN 16384  /* SDP bodies can be quite big, heavy on stack */
+    gchar message_encoded[MAX_JSON_MSG_LEN + 1];
+    GST_TIME_TO_TIMEVAL (now, tv);
+    gmtime_r (&tv.tv_sec, &_tm);
+    strftime (iso8601buf, ISO8601_BUF_SIZE, "%FT%T", &_tm);
+    gst_debug_escape_json (gst_debug_message_get (message), message_encoded,
+        MAX_JSON_MSG_LEN);
+#define PRINT_FMT "\"proc!id\":%d,\"proc!tid\":%ju,\"pri\":\"%s\",\"subsys\":\"%s\",\"file!name\":\"%s\",\"file!line\":%d,\"native!function\":\"%s\",\"native!object\":\"%s\",\"msg\":\"%s\",\"pname\":\"%s\",\"appname\":\"%s\",\"hostname\":\"%s\"}\n"
+    fprintf (log_file,
+        "{\"time\":\"%s.%09luZ\",\"native!time!elapsed\":%lu," PRINT_FMT,
+        iso8601buf, tv_ns, elapsed, pid, (uintptr_t) g_thread_self (),
+        gst_debug_level_get_name_cee (level),
+        gst_debug_category_get_name (category), file, line, function, obj,
+        message_encoded, log_pname, log_appname, log_hostname);
+    fflush (log_file);
+#undef PRINT_FMT
+  } else if (color_mode != GST_DEBUG_COLOR_MODE_OFF) {
 #ifdef G_OS_WIN32
     /* We take a lock to keep colors and content together.
      * Maybe there is a better way but for now this will do the right
@@ -1152,6 +1239,75 @@ gst_debug_level_get_name (GstDebugLevel level)
       g_warning ("invalid level specified for gst_debug_level_get_name");
       return "";
   }
+}
+
+/**
+ * gst_debug_level_get_name_cee:
+ * @level: the level to get the name for
+ *
+ * Get the CEE level string for the specified GStreamer debug level
+ *
+ * Returns: the CEE level name
+ */
+const gchar *
+gst_debug_level_get_name_cee (GstDebugLevel level)
+{
+  switch (level) {
+    case GST_LEVEL_NONE:
+      return "";
+    case GST_LEVEL_ERROR:
+      return "ERROR";
+    case GST_LEVEL_WARNING:
+      return "WARN";
+    case GST_LEVEL_INFO:
+    case GST_LEVEL_DEBUG:
+    case GST_LEVEL_LOG:
+    case GST_LEVEL_FIXME:
+    case GST_LEVEL_TRACE:
+    case GST_LEVEL_MEMDUMP:
+      return "DEBUG";
+    default:
+      g_warning ("invalid level specified for gst_debug_level_get_name_cee");
+      return "";
+  }
+}
+
+/**
+ * gst_debug_escape_json:
+ * @src: the raw string to be encoded
+ * @dest: a buffer to store the encoded string
+ * @dest_size: the maximum number of bytes buffer can accept
+ *
+ * Encode @src into a JSON-escaped string as defined in
+ * RFC 7159 section 7
+ * https://datatracker.ietf.org/doc/html/rfc7159#section-7
+ *
+ * The output is silently truncated if it would be
+ * longer than @dest_size
+ */
+void
+gst_debug_escape_json (const gchar * src, gchar * dest, gsize dest_size)
+{
+  static const char *json_special = "\"\\/\b\f\n\r\t";
+  static const char *json_special_replace = "\"\\/bfnrt";
+  const gchar *src_p = src;
+  gchar *dest_p = dest, *dest_end = dest + dest_size - 6;
+  for (; *src_p != 0 && dest_p < dest_end; dest_p++) {
+    const char *special = strchr (json_special, (char) (*src_p));
+    if (special != NULL) {
+      const char *replace = json_special_replace + (special - json_special);
+      *(dest_p++) = '\\';
+      *dest_p = *replace;
+    } else if (*src_p < 0x20) {
+      /* Everything below 0x20 must be escaped */
+      snprintf (dest_p, 7, "\\u%04X", *src_p);
+      dest_p += 5;
+    } else {
+      *dest_p = *src_p;
+    }
+    src_p++;
+  }
+  *dest_p = 0;
 }
 
 /**

--- a/gst/gstinfo.h
+++ b/gst/gstinfo.h
@@ -358,6 +358,10 @@ void            gst_debug_log_default    (GstDebugCategory * category,
 
 const gchar *   gst_debug_level_get_name (GstDebugLevel level);
 
+const gchar *   gst_debug_level_get_name_cee (GstDebugLevel level);
+
+void            gst_debug_escape_json(const gchar *src, gchar *dest, gsize dest_size);
+
 void            gst_debug_add_log_function            (GstLogFunction func,
                                                        gpointer       user_data,
                                                        GDestroyNotify notify);

--- a/gst/gstinfo.h
+++ b/gst/gstinfo.h
@@ -360,6 +360,8 @@ const gchar *   gst_debug_level_get_name (GstDebugLevel level);
 
 const gchar *   gst_debug_level_get_name_cee (GstDebugLevel level);
 
+int             gst_debug_level_get_syslog (GstDebugLevel level);
+
 void            gst_debug_escape_json(const gchar *src, gchar *dest, gsize dest_size);
 
 void            gst_debug_add_log_function            (GstLogFunction func,


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
Please see the related pull request on kurento-media-server
https://github.com/Kurento/kurento-media-server/pull/17

This pull request against GStreamer provides the JSON CEE logging when Kurento is running in the foreground.

The kurento-media-server pull request does the same thing for writing to log files on disk

The changes can be accepted in either order: they don't depend on each other during compilation.

The same change has been proposed in GStreamer upstream:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/847


## What is the new behavior provided by this change?
<!--
Example: "Adding a function to do X",
then explain why it is necessary to have a way to do X.
-->
Please see the related pull request on kurento-media-server
https://github.com/Kurento/kurento-media-server/pull/17


## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, tests ran to see how
your change affects other areas of the code, etc.
-->
Please see the related pull request on kurento-media-server
https://github.com/Kurento/kurento-media-server/pull/17

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
